### PR TITLE
Drop Ember.$.extend in authenticate/resolve

### DIFF
--- a/app/authenticators/django-rest.js
+++ b/app/authenticators/django-rest.js
@@ -15,7 +15,7 @@ export default Base.extend({
       var data = { username: credentials.identification, password: credentials.password };
       _this.makeRequest(_this.serverTokenEndpoint, data).then(function(response) {
         Ember.run(function() {
-          resolve(Ember.$.extend(response));
+          resolve(response);
         });
       }, function(xhr, status, error) {
         Ember.run(function() {


### PR DESCRIPTION
Call to extend was unnecessary and resulted in `ember-simple-auth` not properly updating session, and `authorizer.authorize` coould not access `session.token`.

Or we should call use:
resolve(Ember.$.extend({}, response));

Notice first arg: {}, as extend target object.