### PR TITLE
Fix to work with newer ember simple auth.

### DIFF
--- a/app/authorizers/django-rest.js
+++ b/app/authorizers/django-rest.js
@@ -3,7 +3,8 @@ import isSecureUrl from './../utils/is-secure-url';
 
 export default Base.extend({
   authorize: function(jqXHR, requestOptions) {
-    var accessToken = this.get('session.token');
+    var secureData = this.get('session.secure');
+    var accessToken = secureData.token;
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(accessToken)) {
       if (!isSecureUrl(requestOptions.url)) {
         Ember.Logger.warn('Credentials are transmitted via an insecure connection - use HTTPS to keep them secure.');


### PR DESCRIPTION
I'm not sure exactly when it changed, but now everything is stored under
session.secure instead of straight on the session. This change fixes the
wrong reference.