### PR TITLE
Make authenticate method return error messages.

### DIFF
--- a/app/authenticators/django-rest.js
+++ b/app/authenticators/django-rest.js
@@ -13,15 +13,10 @@ export default Base.extend({
     var _this = this;
     return new Ember.RSVP.Promise(function(resolve, reject) {
       var data = { username: credentials.identification, password: credentials.password };
-      _this.makeRequest(_this.serverTokenEndpoint, data).then(function(response) {
-        Ember.run(function() {
-          resolve(response);
-        });
-      }, function(xhr, status, error) {
-        Ember.run(function() {
-          reject();
-        });
-      });
+      return _this.makeRequest(_this.serverTokenEndpoint, data).then(
+        (response) => Ember.run(null, resolve, response), 
+        (xhr) => Ember.run(null, reject, xhr.responseJSON || xhr.responseText)
+      );
     });
   },
 


### PR DESCRIPTION
Rewrote the authenticate method based on the code in
ember-simple-auth/authenticators/devise.js

Will now return error messages from the server if authentication fails, for
display in templates.
